### PR TITLE
feat: interactive endpoint schema tree

### DIFF
--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import JsonTree from './JsonTree';
 
 type Data =
   | { kind: 'openapi'; sourceUrl?: string; info?: any; paths?: Record<string, any>; components?: any }
@@ -9,15 +10,49 @@ export default function Explorer({ data }: { data: Data }) {
   if ((data as any).kind === 'openapi') {
     const d = data as any;
     const paths = d.paths || {};
-    const endpoints = Object.entries(paths).flatMap(([p, byMethod]) =>
-      Object.keys(byMethod as any).map((m)=> ({ path: p, method: m.toUpperCase() }))
-    );
+    const pathEntries = Object.entries(paths as Record<string, any>);
     return (
       <div>
         <p className="small">Detected <b>OpenAPI</b>{d.sourceUrl ? ` at ${d.sourceUrl}`:''}</p>
-        <h3>Endpoints ({endpoints.length})</h3>
+        <h3>Endpoints ({pathEntries.length})</h3>
         <ul>
-          {endpoints.map((e, i)=>(<li key={i}><code>{e.method}</code> <code>{e.path}</code></li>))}
+          {pathEntries.map(([path, byMethod]) => (
+            <li key={path}>
+              <details>
+                <summary><code>{path}</code></summary>
+                <ul>
+                  {Object.entries(byMethod as Record<string, any>).map(([method, op]) => (
+                    <li key={method}>
+                      <details>
+                        <summary>
+                          <code>{method.toUpperCase()}</code>{op.summary ? ` ${op.summary}` : ''}
+                        </summary>
+                        {op.description && <p className="small">{op.description}</p>}
+                        {op.parameters && (
+                          <section>
+                            <h4>Parameters</h4>
+                            <JsonTree data={op.parameters} />
+                          </section>
+                        )}
+                        {op.requestBody && (
+                          <section>
+                            <h4>Request Body</h4>
+                            <JsonTree data={op.requestBody} />
+                          </section>
+                        )}
+                        {op.responses && (
+                          <section>
+                            <h4>Responses</h4>
+                            <JsonTree data={op.responses} />
+                          </section>
+                        )}
+                      </details>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            </li>
+          ))}
         </ul>
         <details>
           <summary>Raw OpenAPI (truncated)</summary>

--- a/components/JsonTree.tsx
+++ b/components/JsonTree.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface JsonTreeProps {
+  data: any;
+  name?: string;
+}
+
+function isObject(value: any) {
+  return typeof value === 'object' && value !== null;
+}
+
+export default function JsonTree({ data, name }: JsonTreeProps) {
+  if (!isObject(data)) {
+    return (
+      <span>
+        {name ? <><b>{name}</b>: </> : null}
+        <code>{JSON.stringify(data)}</code>
+      </span>
+    );
+  }
+
+  const entries = Object.entries(data as Record<string, any>);
+
+  return (
+    <details>
+      <summary>{name ?? (Array.isArray(data) ? 'array' : 'object')}</summary>
+      <ul>
+        {entries.map(([key, value]) => (
+          <li key={key}>
+            <JsonTree data={value} name={key} />
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+


### PR DESCRIPTION
## Summary
- build a recursive `JsonTree` component for displaying nested objects
- render OpenAPI endpoints as expandable trees with method schemas

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_6899359f20248330a5d4f4e33ee21c30