### PR TITLE
fix: correct reactflow type imports

### DIFF
--- a/components/Graph.tsx
+++ b/components/Graph.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import ReactFlow, { Background, Controls, Node, Edge } from 'reactflow';
+import ReactFlow, { Background, Controls } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
 import 'reactflow/dist/style.css';
 
 export interface GraphOp {


### PR DESCRIPTION
## Summary
- use type-only imports for reactflow node and edge definitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689946e5f8cc83309da99ea98d6241fd