### PR TITLE
fix: dynamically import reactflow to avoid build errors

### DIFF
--- a/components/Graph.tsx
+++ b/components/Graph.tsx
@@ -1,9 +1,19 @@
 'use client';
 
 import React from 'react';
-import ReactFlow, { Background, Controls } from 'reactflow';
+import dynamic from 'next/dynamic';
 import type { Edge, Node } from 'reactflow';
 import 'reactflow/dist/style.css';
+
+const ReactFlow = dynamic(() => import('reactflow').then((m) => m.default), {
+  ssr: false,
+});
+const Background = dynamic(() => import('reactflow').then((m) => m.Background), {
+  ssr: false,
+});
+const Controls = dynamic(() => import('reactflow').then((m) => m.Controls), {
+  ssr: false,
+});
 
 export interface GraphOp {
   id: string;


### PR DESCRIPTION
## Summary
- dynamically import `reactflow` components to avoid module resolution errors in Next.js runtime

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68994c8b711c8330b0d32733edf0b857