### PR TITLE
feat: support custom auth schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev
 
 ## How it works
 
-- Client posts `baseUrl` and `apiKey` to `/api/introspect`.
+- Client posts `baseUrl` and optional auth info (`apiKey`, `headerName`, `authScheme`) to `/api/introspect`.
 - Server tries in order:
   1. **OpenAPI/Swagger**: fetches `/.well-known/openapi.json`, `/openapi.json`, `/swagger.json`, `/v1/openapi.json`.
   2. **GraphQL**: runs an **introspection query** against the given URL.
@@ -31,7 +31,7 @@ npm run dev
 
 ### Security notes
 
-- API keys are **never logged**. In the MVP they are sent only to your serverless function and used as an `Authorization: Bearer ...` header.
+- API keys are **never logged**. In the MVP they are sent only to your serverless function and applied to requests using your chosen header and scheme (e.g. `Authorization: Bearer …`).
 - For production, prefer per‑session secrets and a denylist/allowlist of outbound domains. Do not persist user-provided keys by default.
 
 ## Project structure
@@ -44,7 +44,7 @@ api-explorer/
 │  ├─ layout.tsx                   # base layout
 │  └─ page.tsx                     # UI: form + rendered results
 ├─ components/
-│  ├─ ApiForm.tsx                  # URL/API key form
+│  ├─ ApiForm.tsx                  # URL/auth form
 │  └─ Explorer.tsx                 # renders an outline of the API shape
 ├─ lib/
 │  └─ introspect/

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string }) {
+  async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string; authScheme?: string }) {
     setLoading(true); setError(null); setResult(null);
     try {
       const res = await fetch('/api/introspect', {
@@ -33,7 +33,7 @@ export default function Page() {
     <main className="grid">
       <section className="card">
         <h1>API Explorer</h1>
-        <p className="small">Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent as an Authorization header.</p>
+        <p className="small">Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent using your chosen header and scheme.</p>
         <ApiForm onSubmit={onSubmit} disabled={loading} />
       </section>
       <section className="card">

--- a/components/ApiForm.tsx
+++ b/components/ApiForm.tsx
@@ -1,26 +1,65 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
-export default function ApiForm({ onSubmit, disabled }:{ onSubmit:(p:{baseUrl:string; apiKey?: string; headerName?: string})=>void; disabled?:boolean;}) {
+export default function ApiForm({ onSubmit, disabled }:{ onSubmit:(p:{baseUrl:string; apiKey?: string; headerName?: string; authScheme?: string})=>void; disabled?:boolean;}) {
   const [baseUrl, setBaseUrl] = useState('');
   const [apiKey, setApiKey] = useState('');
   const [headerName, setHeaderName] = useState('Authorization');
+  const [authType, setAuthType] = useState('Bearer');
+  const [customScheme, setCustomScheme] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hn = localStorage.getItem('headerName');
+    if (hn) setHeaderName(hn);
+    const at = localStorage.getItem('authType');
+    if (at) setAuthType(at);
+    const cs = localStorage.getItem('customScheme');
+    if (cs) setCustomScheme(cs);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') localStorage.setItem('headerName', headerName);
+  }, [headerName]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('authType', authType);
+    if (authType === 'Custom') {
+      localStorage.setItem('customScheme', customScheme);
+    } else {
+      localStorage.removeItem('customScheme');
+    }
+  }, [authType, customScheme]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     let url = baseUrl.trim();
     if (!/^https?:\/\//i.test(url)) url = 'https://' + url;
-    onSubmit({ baseUrl: url, apiKey: apiKey.trim() || undefined, headerName: headerName.trim() || undefined });
+    const scheme = authType === 'Custom' ? customScheme.trim() : authType;
+    onSubmit({ baseUrl: url, apiKey: apiKey.trim() || undefined, headerName: headerName.trim() || undefined, authScheme: scheme.trim() || undefined });
   }
+
+  const schemeDisplay = authType === 'Custom' ? customScheme : authType;
+  const placeholder = schemeDisplay ? `Will be sent as ${schemeDisplay} token` : 'API key';
 
   return (
     <form onSubmit={handleSubmit}>
       <label>API Base URL</label>
       <input required placeholder="https://api.example.com" value={baseUrl} onChange={e=>setBaseUrl(e.target.value)} />
       <label>API Key (optional)</label>
-      <input type="password" placeholder="Will be sent as Bearer token" autoComplete="off" value={apiKey} onChange={e=>setApiKey(e.target.value)} />
+      <input type="password" placeholder={placeholder} autoComplete="off" value={apiKey} onChange={e=>setApiKey(e.target.value)} />
       <label>Header Name</label>
       <input placeholder="Authorization" value={headerName} onChange={e=>setHeaderName(e.target.value)} />
+      <label>Token Scheme</label>
+      <select value={authType} onChange={e=>setAuthType(e.target.value)}>
+        <option value="Bearer">Bearer</option>
+        <option value="Basic">Basic</option>
+        <option value="Custom">Custom</option>
+      </select>
+      {authType === 'Custom' && (
+        <input placeholder="Scheme" value={customScheme} onChange={e=>setCustomScheme(e.target.value)} />
+      )}
       <button disabled={disabled} type="submit">Explore</button>
     </form>
   );

--- a/lib/introspect/graphql.ts
+++ b/lib/introspect/graphql.ts
@@ -11,10 +11,10 @@ const INTROSPECTION_QUERY = `
   }
 `;
 
-export async function tryGraphQL(endpoint: string, apiKey?: string, headerName?: string) {
+export async function tryGraphQL(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string) {
   try {
     const body = JSON.stringify({ query: INTROSPECTION_QUERY });
-    const headers = withAuth({ 'content-type': 'application/json' }, apiKey, headerName);
+    const headers = withAuth({ 'content-type': 'application/json' }, apiKey, headerName, authScheme);
     const res = await fetch(endpoint, { method: 'POST', headers, body });
     if (!res.ok) return { ok: false as const };
     const data = await res.json();

--- a/lib/introspect/hal.ts
+++ b/lib/introspect/hal.ts
@@ -1,8 +1,8 @@
 import { withAuth } from './util';
 
-export async function tryHal(endpoint: string, apiKey?: string, headerName?: string) {
+export async function tryHal(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string) {
   try {
-    const res = await fetch(endpoint, { headers: withAuth({}, apiKey, headerName) });
+    const res = await fetch(endpoint, { headers: withAuth({}, apiKey, headerName, authScheme) });
     if (!res.ok) return { ok: false as const };
     const ct = res.headers.get('content-type') || '';
     if (!ct.includes('json')) return { ok: false as const };

--- a/lib/introspect/jsonapi.ts
+++ b/lib/introspect/jsonapi.ts
@@ -1,8 +1,8 @@
 import { withAuth } from './util';
 
-export async function tryJsonApi(endpoint: string, apiKey?: string, headerName?: string) {
+export async function tryJsonApi(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string) {
   try {
-    const res = await fetch(endpoint, { headers: withAuth({}, apiKey, headerName) });
+    const res = await fetch(endpoint, { headers: withAuth({}, apiKey, headerName, authScheme) });
     if (!res.ok) return { ok: false as const };
     const ct = res.headers.get('content-type') || '';
     if (!ct.includes('application/vnd.api+json')) return { ok: false as const };

--- a/lib/introspect/openapi.ts
+++ b/lib/introspect/openapi.ts
@@ -7,11 +7,11 @@ const candidates = [
   '/v1/openapi.json'
 ];
 
-export async function tryOpenApi(baseUrl: string, apiKey?: string, headerName?: string) {
+export async function tryOpenApi(baseUrl: string, apiKey?: string, headerName?: string, authScheme?: string) {
   for (const path of candidates) {
     const url = new URL(path.replace(/^\/+/, '/'), baseUrl).toString();
     try {
-      const doc = await fetchJson(url, { headers: withAuth({}, apiKey, headerName) });
+      const doc = await fetchJson(url, { headers: withAuth({}, apiKey, headerName, authScheme) });
       if (doc && (doc.openapi || doc.swagger) && doc.paths) {
         return {
           ok: true as const,

--- a/lib/introspect/util.test.ts
+++ b/lib/introspect/util.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { withAuth } from './util.ts';
+
+test('adds Bearer scheme by default', () => {
+  const h = new Headers(withAuth({}, 'secret'));
+  assert.equal(h.get('Authorization'), 'Bearer secret');
+});
+
+test('supports Basic scheme', () => {
+  const creds = 'user:pass';
+  const expected = 'Basic ' + Buffer.from(creds).toString('base64');
+  const h = new Headers(withAuth({}, creds, undefined, 'Basic'));
+  assert.equal(h.get('Authorization'), expected);
+});
+
+test('supports custom scheme and header', () => {
+  const h = new Headers(withAuth({}, 't', 'X-API-Key', 'Token'));
+  assert.equal(h.get('X-API-Key'), 'Token t');
+});

--- a/lib/introspect/util.ts
+++ b/lib/introspect/util.ts
@@ -14,9 +14,22 @@ export async function fetchJson(url: string, init?: RequestInit, timeoutMs=8000)
   }
 }
 
-export function withAuth(headers: HeadersInit, apiKey?: string, headerName?: string): HeadersInit {
+export function withAuth(headers: HeadersInit, apiKey?: string, headerName?: string, authScheme?: string): HeadersInit {
   if (!apiKey) return headers;
   const h = new Headers(headers);
-  h.set(headerName || 'Authorization', headerName?.toLowerCase() === 'authorization' || !headerName ? `Bearer ${apiKey}` : apiKey);
+  const name = headerName || 'Authorization';
+  let value: string;
+  if (authScheme && authScheme.trim()) {
+    if (/^basic$/i.test(authScheme)) {
+      value = `Basic ${Buffer.from(apiKey).toString('base64')}`;
+    } else {
+      value = `${authScheme.trim()} ${apiKey}`.trim();
+    }
+  } else if (!headerName || headerName.toLowerCase() === 'authorization') {
+    value = `Bearer ${apiKey}`;
+  } else {
+    value = apiKey;
+  }
+  h.set(name, value);
   return h;
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx lib/introspect/jsonapi.test.ts && tsx lib/introspect/hal.test.ts"
+    "test": "tsx lib/introspect/jsonapi.test.ts && tsx lib/introspect/hal.test.ts && tsx lib/introspect/util.test.ts"
   },
   "dependencies": {
     "next": "14.2.4",


### PR DESCRIPTION
## Summary
- allow selecting header name and auth scheme in the API form
- persist auth header and scheme via localStorage
- extend auth util and server to send Bearer, Basic or custom tokens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689951060cb88330867c9b366f703ebf