### PR TITLE
Display OpenAPI schema tree with $ref links

### DIFF
--- a/components/JsonTree.tsx
+++ b/components/JsonTree.tsx
@@ -10,11 +10,35 @@ function isObject(value: any) {
 }
 
 export default function JsonTree({ data, name }: JsonTreeProps) {
+  if (isObject(data) && typeof (data as any).$ref === 'string') {
+    const ref = (data as any).$ref as string;
+    const m = ref.match(/^#\/components\/schemas\/([^/]+)$/);
+    if (m) {
+      const refName = m[1];
+      return (
+        <span>
+          {name ? (
+            <>
+              <b>{name}</b>: <a href={`#schema-${refName}`}>{refName}</a>
+            </>
+          ) : (
+            <a href={`#schema-${refName}`}>{refName}</a>
+          )}
+        </span>
+      );
+    }
+  }
+
   if (!isObject(data)) {
     return (
       <span>
-        {name ? <><b>{name}</b>: </> : null}
-        <code>{JSON.stringify(data)}</code>
+        {name ? (
+          <>
+            <b>{name}</b>: <code>{JSON.stringify(data)}</code>
+          </>
+        ) : (
+          <code>{JSON.stringify(data)}</code>
+        )}
       </span>
     );
   }

--- a/components/SchemaTree.tsx
+++ b/components/SchemaTree.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+interface SchemaTreeProps {
+  name: string;
+  schema: any;
+  components: Record<string, any>;
+}
+
+function SchemaNode({ schema, components, seen }: { schema: any; components: Record<string, any>; seen: Set<string>; }) {
+  if (!schema || typeof schema !== 'object') {
+    return <code>{JSON.stringify(schema)}</code>;
+  }
+
+  if (schema.$ref && typeof schema.$ref === 'string') {
+    const m = schema.$ref.match(/^#\/components\/schemas\/([^/]+)$/);
+    if (m) {
+      const refName = m[1];
+      return (
+        <>
+          <a href={`#schema-${refName}`}>{refName}</a>
+          {!seen.has(refName) && (
+            <SchemaNode schema={components[refName]} components={components} seen={new Set([...seen, refName])} />
+          )}
+        </>
+      );
+    }
+  }
+
+  if (schema.type === 'array' && schema.items) {
+    return (
+      <>
+        array of <SchemaNode schema={schema.items} components={components} seen={seen} />
+      </>
+    );
+  }
+
+  const props = schema.properties || {};
+  if (schema.type === 'object' || Object.keys(props).length > 0) {
+    return (
+      <ul>
+        {Object.entries(props).map(([prop, sub]) => (
+          <li key={prop}>
+            <b>{prop}</b>: <SchemaNode schema={sub} components={components} seen={seen} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (schema.enum) {
+    return <code>{schema.enum.join(' | ')}</code>;
+  }
+
+  if (schema.type) {
+    return <code>{schema.type}</code>;
+  }
+
+  return <code>any</code>;
+}
+
+export default function SchemaTree({ name, schema, components }: SchemaTreeProps) {
+  return (
+    <details id={`schema-${name}`}>
+      <summary>
+        <code>{name}</code>
+      </summary>
+      <SchemaNode schema={schema} components={components} seen={new Set([name])} />
+    </details>
+  );
+}


### PR DESCRIPTION
## Summary
- list component schemas in a navigable tree
- link endpoint request/response sections to referenced schemas
- turn `$ref` objects into links for easier navigation

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689953c507a88330bd8951896e0c25ca