### PR TITLE
Support query parameter auth keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev
 
 ## How it works
 
-- Client posts `baseUrl` and optional auth info (`apiKey`, `headerName`, `authScheme`) to `/api/introspect`.
+- Client posts `baseUrl` and optional auth info (`apiKey`, `headerName`, `authScheme`, `authMethod`, `queryName`) to `/api/introspect`.
 - Server tries in order:
   1. **OpenAPI/Swagger**: fetches `/.well-known/openapi.json`, `/openapi.json`, `/swagger.json`, `/v1/openapi.json`.
   2. **GraphQL**: runs an **introspection query** against the given URL.
@@ -31,7 +31,7 @@ npm run dev
 
 ### Security notes
 
-- API keys are **never logged**. In the MVP they are sent only to your serverless function and applied to requests using your chosen header and scheme (e.g. `Authorization: Bearer …`).
+- API keys are **never logged**. In the MVP they are sent only to your serverless function and applied to requests using your chosen header/scheme or query parameter.
 - For production, prefer per‑session secrets and a denylist/allowlist of outbound domains. Do not persist user-provided keys by default.
 
 ## Project structure
@@ -66,7 +66,7 @@ api-explorer/
 
 - [ ] Render an interactive **endpoint -> schema** tree.
 - [ ] Add simple **graph view** (React Flow or Cytoscape).
-- [ ] Support **API-key-in-query** and **custom header** schemes.
+- [x] Support **API-key-in-query** and **custom header** schemes.
 - [ ] Cache introspection results (LRU) to reduce outbound calls.
 - [ ] Add **rate limiting** and target allowlist for the proxy.
 - [ ] Add **JSON:API** and **HAL** detectors.

--- a/app/api/introspect/route.ts
+++ b/app/api/introspect/route.ts
@@ -3,7 +3,7 @@ import { tryOpenApi } from '../../../lib/introspect/openapi';
 import { tryGraphQL } from '../../../lib/introspect/graphql';
 import { tryJsonApi } from '../../../lib/introspect/jsonapi';
 import { tryHal } from '../../../lib/introspect/hal';
-import { withAuth } from '../../../lib/introspect/util';
+import { withAuth, withQuery } from '../../../lib/introspect/util';
 
 function sanitizeUrl(url: string) {
   const u = new URL(url);
@@ -13,29 +13,36 @@ function sanitizeUrl(url: string) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { baseUrl, apiKey, headerName, authScheme } = await req.json();
+    const { baseUrl, apiKey, headerName, authScheme, authMethod, queryName } = await req.json();
     if (!baseUrl) return NextResponse.json({ error: 'baseUrl required' }, { status: 400 });
     const url = sanitizeUrl(baseUrl);
 
     // Try OpenAPI / Swagger
-    const openapi = await tryOpenApi(url, apiKey, headerName, authScheme);
+    const openapi = await tryOpenApi(url, apiKey, headerName, authScheme, authMethod, queryName);
     if (openapi.ok) return NextResponse.json(openapi.data);
 
     // Try GraphQL at the same endpoint
-    const gql = await tryGraphQL(url, apiKey, headerName, authScheme);
+    const gql = await tryGraphQL(url, apiKey, headerName, authScheme, authMethod, queryName);
     if (gql.ok) return NextResponse.json(gql.data);
 
     // Try JSON:API at base URL
-    const ja = await tryJsonApi(url, apiKey, headerName, authScheme);
+    const ja = await tryJsonApi(url, apiKey, headerName, authScheme, authMethod, queryName);
     if (ja.ok) return NextResponse.json(ja.data);
 
     // Try HAL at base URL
-    const hal = await tryHal(url, apiKey, headerName, authScheme);
+    const hal = await tryHal(url, apiKey, headerName, authScheme, authMethod, queryName);
     if (hal.ok) return NextResponse.json(hal.data);
 
     // Fallback: fetch base URL and return small preview (no guessing yet)
     try {
-      const res = await fetch(url, { headers: withAuth({}, apiKey, headerName, authScheme) });
+      let fetchUrl = url;
+      let headers: HeadersInit = {};
+      if (authMethod === 'query') {
+        fetchUrl = withQuery(fetchUrl, apiKey, queryName);
+      } else {
+        headers = withAuth(headers, apiKey, headerName, authScheme);
+      }
+      const res = await fetch(fetchUrl, { headers });
       const ct = res.headers.get('content-type') || '';
       const body = ct.includes('json') ? await res.json() : await res.text();
       return NextResponse.json({ kind: 'unknown', note: 'No OpenAPI/GraphQL detected at common locations', preview: typeof body === 'string' ? body.slice(0, 2000) : body });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string; authScheme?: string }) {
+  async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string; authScheme?: string; authMethod?: string; queryName?: string }) {
     setLoading(true); setError(null); setResult(null);
     try {
       const res = await fetch('/api/introspect', {
@@ -33,7 +33,7 @@ export default function Page() {
     <main className="grid">
       <section className="card">
         <h1>API Explorer</h1>
-        <p className="small">Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent using your chosen header and scheme.</p>
+        <p className="small">Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent using your chosen header or query parameter.</p>
         <ApiForm onSubmit={onSubmit} disabled={loading} />
       </section>
       <section className="card">

--- a/lib/introspect/graphql.ts
+++ b/lib/introspect/graphql.ts
@@ -1,4 +1,4 @@
-import { fetchJson, withAuth } from './util';
+import { withAuth, withQuery } from './util';
 
 // Minimal introspection query (shortened variant)
 const INTROSPECTION_QUERY = `
@@ -11,11 +11,17 @@ const INTROSPECTION_QUERY = `
   }
 `;
 
-export async function tryGraphQL(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string) {
+export async function tryGraphQL(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string, authMethod?: string, queryName?: string) {
   try {
     const body = JSON.stringify({ query: INTROSPECTION_QUERY });
-    const headers = withAuth({ 'content-type': 'application/json' }, apiKey, headerName, authScheme);
-    const res = await fetch(endpoint, { method: 'POST', headers, body });
+    let url = endpoint;
+    let headers: HeadersInit = { 'content-type': 'application/json' };
+    if (authMethod === 'query') {
+      url = withQuery(url, apiKey, queryName);
+    } else {
+      headers = withAuth(headers, apiKey, headerName, authScheme);
+    }
+    const res = await fetch(url, { method: 'POST', headers, body });
     if (!res.ok) return { ok: false as const };
     const data = await res.json();
     if (data?.data?.__schema) {

--- a/lib/introspect/hal.ts
+++ b/lib/introspect/hal.ts
@@ -1,8 +1,15 @@
-import { withAuth } from './util';
+import { withAuth, withQuery } from './util';
 
-export async function tryHal(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string) {
+export async function tryHal(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string, authMethod?: string, queryName?: string) {
   try {
-    const res = await fetch(endpoint, { headers: withAuth({}, apiKey, headerName, authScheme) });
+    let url = endpoint;
+    let headers: HeadersInit = {};
+    if (authMethod === 'query') {
+      url = withQuery(url, apiKey, queryName);
+    } else {
+      headers = withAuth(headers, apiKey, headerName, authScheme);
+    }
+    const res = await fetch(url, { headers });
     if (!res.ok) return { ok: false as const };
     const ct = res.headers.get('content-type') || '';
     if (!ct.includes('json')) return { ok: false as const };

--- a/lib/introspect/jsonapi.ts
+++ b/lib/introspect/jsonapi.ts
@@ -1,8 +1,15 @@
-import { withAuth } from './util';
+import { withAuth, withQuery } from './util';
 
-export async function tryJsonApi(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string) {
+export async function tryJsonApi(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string, authMethod?: string, queryName?: string) {
   try {
-    const res = await fetch(endpoint, { headers: withAuth({}, apiKey, headerName, authScheme) });
+    let url = endpoint;
+    let headers: HeadersInit = {};
+    if (authMethod === 'query') {
+      url = withQuery(url, apiKey, queryName);
+    } else {
+      headers = withAuth(headers, apiKey, headerName, authScheme);
+    }
+    const res = await fetch(url, { headers });
     if (!res.ok) return { ok: false as const };
     const ct = res.headers.get('content-type') || '';
     if (!ct.includes('application/vnd.api+json')) return { ok: false as const };

--- a/lib/introspect/util.test.ts
+++ b/lib/introspect/util.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { withAuth } from './util.ts';
+import { withAuth, withQuery } from './util.ts';
 
 test('adds Bearer scheme by default', () => {
   const h = new Headers(withAuth({}, 'secret'));
@@ -17,4 +17,9 @@ test('supports Basic scheme', () => {
 test('supports custom scheme and header', () => {
   const h = new Headers(withAuth({}, 't', 'X-API-Key', 'Token'));
   assert.equal(h.get('X-API-Key'), 'Token t');
+});
+
+test('appends API key to query', () => {
+  const url = withQuery('https://example.com/data', 'abc', 'api_key');
+  assert.equal(url, 'https://example.com/data?api_key=abc');
 });

--- a/lib/introspect/util.ts
+++ b/lib/introspect/util.ts
@@ -33,3 +33,10 @@ export function withAuth(headers: HeadersInit, apiKey?: string, headerName?: str
   h.set(name, value);
   return h;
 }
+
+export function withQuery(url: string, apiKey?: string, queryName = 'key'): string {
+  if (!apiKey) return url;
+  const u = new URL(url);
+  u.searchParams.append(queryName || 'key', apiKey);
+  return u.toString();
+}


### PR DESCRIPTION
## Summary
- allow selecting header or query auth in API form
- support query-param API keys in introspection utilities and server route
- document query auth and add tests for query helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995a6f85a4833099aae2756a758254