### PR TITLE
Fix OpenAPI detection

### DIFF
--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -7,7 +7,7 @@ import GraphView from './GraphView';
 import { isOpenApi, collectOperations, buildCapabilityMatrix, resolveSchemaRef, pickPrimaryResponse } from '../lib/openapi/normalize';
 
 type Data =
-  | { kind: 'openapi'; sourceUrl?: string; info?: any; paths?: Record<string, any>; components?: any }
+  | { kind: 'openapi'; openapi?: string; swagger?: string; sourceUrl?: string; info?: any; paths?: Record<string, any>; components?: any }
   | { kind: 'graphql'; types: Array<{ name: string; kind: string }>; queryType?: string; mutationType?: string }
   | { kind: 'unknown'; note: string };
 

--- a/lib/introspect/openapi.ts
+++ b/lib/introspect/openapi.ts
@@ -17,7 +17,15 @@ export async function tryOpenApi(baseUrl: string, apiKey?: string, headerName?: 
         if (doc && (doc.openapi || doc.swagger) && doc.paths) {
           return {
             ok: true as const,
-            data: { kind: 'openapi', sourceUrl: url, info: doc.info, paths: doc.paths, components: doc.components }
+            data: {
+              kind: 'openapi',
+              sourceUrl: url,
+              info: doc.info,
+              paths: doc.paths,
+              components: doc.components,
+              openapi: doc.openapi,
+              swagger: doc.swagger
+            }
           };
         }
       } else {
@@ -25,7 +33,15 @@ export async function tryOpenApi(baseUrl: string, apiKey?: string, headerName?: 
         if (doc && (doc.openapi || doc.swagger) && doc.paths) {
           return {
             ok: true as const,
-            data: { kind: 'openapi', sourceUrl: url, info: doc.info, paths: doc.paths, components: doc.components }
+            data: {
+              kind: 'openapi',
+              sourceUrl: url,
+              info: doc.info,
+              paths: doc.paths,
+              components: doc.components,
+              openapi: doc.openapi,
+              swagger: doc.swagger
+            }
           };
         }
       }


### PR DESCRIPTION
## Summary
- include `openapi`/`swagger` version info when fetching OpenAPI specs
- allow Explorer component to accept version fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689961a06a388330bf4837cb677a0034