### PR TITLE
feat: detect REST JSON endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ npm run dev
 - Server tries in order:
   1. **OpenAPI/Swagger**: fetches `/.well-known/openapi.json`, `/openapi.json`, `/swagger.json`, `/v1/openapi.json`.
   2. **GraphQL**: runs an **introspection query** against the given URL.
-  3. **Fallback**: makes a lightweight `GET baseUrl` and attempts to classify JSON shape (very limited in MVP).
+  3. **JSON:API** and **HAL** detectors at base URL.
+  4. **Plain REST JSON**: infers fields from an array/object and suggests item URLs.
+  5. **Fallback**: makes a lightweight `GET baseUrl` and returns a small preview.
 - Result is normalized and rendered in the UI.
 
 ### Security notes

--- a/app/api/introspect/route.ts
+++ b/app/api/introspect/route.ts
@@ -3,6 +3,7 @@ import { tryOpenApi } from '../../../lib/introspect/openapi';
 import { tryGraphQL } from '../../../lib/introspect/graphql';
 import { tryJsonApi } from '../../../lib/introspect/jsonapi';
 import { tryHal } from '../../../lib/introspect/hal';
+import { tryRest } from '../../../lib/introspect/rest';
 import { withAuth, withQuery } from '../../../lib/introspect/util';
 
 function sanitizeUrl(url: string) {
@@ -32,6 +33,10 @@ export async function POST(req: NextRequest) {
     // Try HAL at base URL
     const hal = await tryHal(url, apiKey, headerName, authScheme, authMethod, queryName);
     if (hal.ok) return NextResponse.json(hal.data);
+
+    // Try plain REST JSON at base URL
+    const rest = await tryRest(url, apiKey, headerName, authScheme, authMethod, queryName);
+    if (rest.ok) return NextResponse.json(rest.data);
 
     // Fallback: fetch base URL and return small preview (no guessing yet)
     try {

--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -4,11 +4,13 @@ import React, { useMemo, useState } from 'react';
 import CapabilityMatrix from './CapabilityMatrix';
 import SchemaTree from './SchemaTree';
 import GraphView from './GraphView';
+import RestView from './RestView';
 import { isOpenApi, collectOperations, buildCapabilityMatrix, resolveSchemaRef, pickPrimaryResponse } from '../lib/openapi/normalize';
 
 type Data =
   | { kind: 'openapi'; openapi?: string; swagger?: string; sourceUrl?: string; info?: any; paths?: Record<string, any>; components?: any }
   | { kind: 'graphql'; types: Array<{ name: string; kind: string }>; queryType?: string; mutationType?: string }
+  | { kind: 'rest'; resource: string; idKey?: string; fields: Array<{ name: string; type: string }>; sample: any; itemUrlTemplate?: string }
   | { kind: 'unknown'; note: string };
 
 export default function Explorer({ data }: { data: Data }) {
@@ -105,6 +107,10 @@ export default function Explorer({ data }: { data: Data }) {
         </ul>
       </div>
     );
+  }
+
+  if ((data as any).kind === 'rest') {
+    return <RestView data={data} />;
   }
 
   const u = data as any;

--- a/components/RestView.tsx
+++ b/components/RestView.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useState } from 'react';
+
+function get(obj: any, path: string) {
+  return path.split('.').reduce((o, k) => (o ? (o as any)[k] : undefined), obj);
+}
+
+export default function RestView({ data }: { data: any }) {
+  const { resource, idKey, fields, sample, itemUrlTemplate } = data;
+  const [id, setId] = useState('');
+  const [item, setItem] = useState<any | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function fetchItem() {
+    if (!itemUrlTemplate) return;
+    setLoading(true);
+    try {
+      const url = itemUrlTemplate.replace('{id}', encodeURIComponent(id));
+      const res = await fetch(url);
+      const ct = res.headers.get('content-type') || '';
+      const body = ct.includes('json') ? await res.json() : await res.text();
+      setItem(body);
+    } catch (e) {
+      setItem({ error: (e as any)?.message || 'Request failed' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (Array.isArray(sample)) {
+    const scalar = fields.filter((f: any) => !['object', 'array'].includes(f.type));
+    return (
+      <div>
+        <p className="small">Detected <b>REST JSON</b> resource <code>{resource}</code></p>
+        <div style={{ overflowX: 'auto' }}>
+          <table>
+            <thead>
+              <tr>
+                {scalar.map((f:any) => (<th key={f.name}>{f.name}</th>))}
+                <th>raw</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sample.map((row:any, i:number) => (
+                <tr key={i}>
+                  {scalar.map((f:any) => (
+                    <td key={f.name}>{String(get(row, f.name) ?? '')}</td>
+                  ))}
+                  <td><details><summary>…</summary><pre>{JSON.stringify(row, null, 2)}</pre></details></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {itemUrlTemplate && idKey && (
+          <div style={{ marginTop: '1rem' }}>
+            <label>Try item ({idKey})</label>
+            <input value={id} onChange={e=>setId(e.target.value)} />
+            <button onClick={fetchItem} disabled={loading || !id}>Fetch</button>
+            {item && (
+              <details open style={{ marginTop: '0.5rem' }}>
+                <summary>Result</summary>
+                <pre>{JSON.stringify(item, null, 2)}</pre>
+              </details>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="small">Detected <b>REST JSON</b> resource <code>{resource}</code></p>
+      <h3>Fields</h3>
+      <ul>
+        {fields.map((f:any) => (
+          <li key={f.name}><code>{f.name}</code> <span className="small">{f.type}</span></li>
+        ))}
+      </ul>
+      <details style={{ marginTop:'1rem' }}>
+        <summary>Sample</summary>
+        <pre>{JSON.stringify(sample, null, 2)}</pre>
+      </details>
+    </div>
+  );
+}

--- a/lib/introspect/rest.test.ts
+++ b/lib/introspect/rest.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tryRest } from './rest.ts';
+
+test('detects REST JSON array', async () => {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/people.json') {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify([
+        { id: 1, name: 'Alice', nested: { foo: 'bar' } }
+      ]));
+    } else {
+      res.statusCode = 404; res.end();
+    }
+  });
+  await new Promise<void>(resolve => server.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+  const base = `http://127.0.0.1:${port}`;
+  const url = `${base}/people.json`;
+  const result = await tryRest(url);
+  assert.equal(result.ok, true);
+  const data: any = result.data;
+  assert.equal(data.kind, 'rest');
+  assert.equal(data.resource, 'people');
+  assert.equal(data.idKey, 'id');
+  assert.equal(data.itemUrlTemplate, `${base}/people/{id}.json`);
+  assert.ok(Array.isArray(data.sample));
+  assert.ok(data.fields.find((f:any)=>f.name==='id'));
+  assert.ok(data.fields.find((f:any)=>f.name==='name'));
+  assert.ok(data.fields.find((f:any)=>f.name==='nested.foo'));
+  server.close();
+});

--- a/lib/introspect/rest.ts
+++ b/lib/introspect/rest.ts
@@ -1,0 +1,95 @@
+import { withAuth, withQuery } from './util';
+
+function deriveResource(url: string) {
+  try {
+    const u = new URL(url);
+    const segments = u.pathname.replace(/\/+$/, '').split('/');
+    const last = segments.pop() || '';
+    return last.replace(/\.[^.]+$/, '');
+  } catch {
+    return '';
+  }
+}
+
+function guessIdKey(item: any) {
+  if (!item || typeof item !== 'object') return undefined;
+  for (const key of Object.keys(item)) {
+    const lower = key.toLowerCase();
+    if (lower === 'id' || lower === '_id' || lower === 'uuid' || lower === 'guid') return key;
+  }
+  return undefined;
+}
+
+function inferFields(sample: any[]) {
+  const acc: Record<string, string> = {};
+  function walk(obj: any, prefix = '') {
+    if (!obj || typeof obj !== 'object') return;
+    for (const [k, v] of Object.entries(obj)) {
+      const name = prefix ? `${prefix}.${k}` : k;
+      const t = Array.isArray(v) ? 'array' : typeof v;
+      if (t === 'object' && v !== null) {
+        walk(v, name);
+      } else {
+        if (!(name in acc)) acc[name] = t;
+      }
+    }
+  }
+  for (const item of sample.slice(0, 50)) walk(item);
+  return Object.entries(acc).map(([name, type]) => ({ name, type }));
+}
+
+function buildItemTemplate(url: string, resource: string, idKey?: string, apiKey?: string, authMethod?: string, queryName?: string) {
+  if (!idKey) return undefined;
+  try {
+    const u = new URL(url);
+    const segments = u.pathname.replace(/\/+$/, '').split('/');
+    const last = segments.pop() || '';
+    const match = last.match(/(\.[^.]+)$/);
+    const ext = match ? match[1] : '';
+    const prefix = segments.join('/');
+    let path = `${prefix}/${resource}/{id}${ext}`;
+    if (!path.startsWith('/')) path = '/' + path;
+    let query = u.search;
+    if (authMethod === 'query' && apiKey) {
+      const sp = new URLSearchParams(query);
+      sp.set(queryName || 'key', apiKey);
+      query = `?${sp.toString()}`;
+    }
+    return `${u.protocol}//${u.host}${path}${query}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function tryRest(endpoint: string, apiKey?: string, headerName?: string, authScheme?: string, authMethod?: string, queryName?: string) {
+  try {
+    let url = endpoint;
+    let headers: HeadersInit = {};
+    if (authMethod === 'query') {
+      url = withQuery(url, apiKey, queryName);
+    } else {
+      headers = withAuth(headers, apiKey, headerName, authScheme);
+    }
+    const res = await fetch(url, { headers });
+    if (!res.ok) return { ok: false as const };
+    const ct = res.headers.get('content-type') || '';
+    if (!ct.includes('json')) return { ok: false as const };
+    const body = await res.json();
+    if (!body) return { ok: false as const };
+    const resource = deriveResource(endpoint);
+    if (Array.isArray(body) && body.every(i => i && typeof i === 'object')) {
+      const sample = body.slice(0, 50);
+      const fields = inferFields(sample);
+      const idKey = guessIdKey(sample[0]);
+      const itemUrlTemplate = buildItemTemplate(endpoint, resource, idKey, apiKey, authMethod, queryName);
+      return { ok: true as const, data: { kind: 'rest', resource, idKey, fields, sample, itemUrlTemplate } };
+    } else if (body && typeof body === 'object') {
+      const fields = inferFields([body]);
+      return { ok: true as const, data: { kind: 'rest', resource, fields, sample: body } };
+    }
+    return { ok: false as const };
+  } catch {
+    return { ok: false as const };
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx lib/introspect/jsonapi.test.ts && tsx lib/introspect/hal.test.ts && tsx lib/introspect/util.test.ts && tsx lib/openapi/normalize.test.ts"
+    "test": "tsx lib/introspect/jsonapi.test.ts && tsx lib/introspect/hal.test.ts && tsx lib/introspect/rest.test.ts && tsx lib/introspect/util.test.ts && tsx lib/openapi/normalize.test.ts"
   },
   "dependencies": {
     "next": "14.2.4",


### PR DESCRIPTION
## Summary
- detect plain REST JSON responses and infer resources, fields, and item templates
- render REST resources in a table with sample data and detail-item fetcher
- document REST JSON detection and add unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68996ac4b138833085a7d693c5fa08df