### PR TITLE
feat: add projects pane with persistence

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,4 +10,5 @@ button { cursor: pointer; }
 pre { overflow: auto; background: rgba(0,0,0,.04); padding: .75rem; border-radius: 12px; }
 .small { font-size: .875rem; opacity: .75; }
 .grid { display:grid; gap: 1rem; grid-template-columns: 1fr 1fr; }
-@media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+.grid.with-projects { grid-template-columns: 200px 1fr 1fr; }
+@media (max-width: 900px) { .grid, .grid.with-projects { grid-template-columns: 1fr; } }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,49 @@
 'use client';
-import React, { useState } from 'react';
-import ApiForm from '../components/ApiForm';
-import Explorer from '../components/Explorer';
+import React, { useState, useEffect } from 'react';
+import ApiForm from "../components/ApiForm";
+import Explorer from "../components/Explorer";
+import ProjectsPane, { Project } from "../components/ProjectsPane";
 
 export default function Page() {
   const [result, setResult] = useState<any | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [showProjects, setShowProjects] = useState(true);
+  const [lastPayload, setLastPayload] = useState<any | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = localStorage.getItem("projects");
+      if (raw) setProjects(JSON.parse(raw));
+    } catch {}
+  }, []);
+
+  function persist(list: Project[]) {
+    if (typeof window !== "undefined")
+      localStorage.setItem("projects", JSON.stringify(list));
+  }
+
+  function handleSaveProject() {
+    if (!result) return;
+    const name = prompt("Project name?");
+    if (!name) return;
+    const newList = [
+      ...projects.filter((p) => p.name !== name),
+      { name, result, baseUrl: lastPayload?.baseUrl },
+    ];
+    setProjects(newList);
+    persist(newList);
+  }
+
+  function handleSelectProject(p: Project) {
+    setResult(p.result);
+    setShowProjects(false);
+  }
 
   async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string; authScheme?: string; authMethod?: string; queryName?: string }) {
-    setLoading(true); setError(null); setResult(null);
+    setLoading(true); setError(null); setResult(null); setLastPayload(payload);
     try {
       const res = await fetch('/api/introspect', {
         method: 'POST',
@@ -30,19 +64,45 @@ export default function Page() {
   }
 
   return (
-    <main className="grid">
-      <section className="card">
-        <h1>API Explorer</h1>
-        <p className="small">Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent using your chosen header or query parameter.</p>
-        <ApiForm onSubmit={onSubmit} disabled={loading} />
-      </section>
-      <section className="card">
-        <h2>Result</h2>
-        {loading && <p>Scanning…</p>}
-        {error && <p style={{color:'crimson'}}>Error: {error}</p>}
-        {!loading && !error && result && <Explorer data={result}/>}
-        {!loading && !error && !result && <p className="small">Results will appear here.</p>}
-      </section>
-    </main>
+    <>
+      {!showProjects && (
+        <button onClick={() => setShowProjects(true)} style={{ width: "auto", marginBottom: "1rem" }}>
+          Show Projects
+        </button>
+      )}
+      <main className={`grid ${showProjects ? "with-projects" : ""}`}>
+        {showProjects && (
+          <section className="card">
+            <ProjectsPane
+              projects={projects}
+              onSelect={handleSelectProject}
+              onClose={() => setShowProjects(false)}
+            />
+          </section>
+        )}
+        <section className="card">
+          <h1>API Explorer</h1>
+          <p className="small">
+            Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent using your chosen header or query
+            parameter.
+          </p>
+          <ApiForm onSubmit={onSubmit} disabled={loading} />
+        </section>
+        <section className="card">
+          <h2>Result</h2>
+          {loading && <p>Scanning…</p>}
+          {error && <p style={{ color: "crimson" }}>Error: {error}</p>}
+          {!loading && !error && result && (
+            <>
+              <button onClick={handleSaveProject} style={{ width: "auto", marginBottom: ".5rem" }}>
+                Save Project
+              </button>
+              <Explorer data={result} />
+            </>
+          )}
+          {!loading && !error && !result && <p className="small">Results will appear here.</p>}
+        </section>
+      </main>
+    </>
   );
 }

--- a/components/ProjectsPane.tsx
+++ b/components/ProjectsPane.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+export interface Project {
+  name: string;
+  result: any;
+  baseUrl?: string;
+}
+
+export default function ProjectsPane({ projects, onSelect, onClose }:{ projects: Project[]; onSelect:(p:Project)=>void; onClose:()=>void; }) {
+  return (
+    <div>
+      <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+        <h2 style={{margin:0}}>Projects</h2>
+        <button onClick={onClose} style={{width:'auto'}}>×</button>
+      </div>
+      {projects.length === 0 && <p className="small">No projects saved.</p>}
+      <ul style={{listStyle:'none',padding:0,margin:0}}>
+        {projects.map(p => (
+          <li key={p.name} style={{marginTop:'.5rem'}}>
+            <button onClick={()=>onSelect(p)} style={{width:'100%',textAlign:'left'}}>{p.name}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add collapsible projects pane to store and reopen API results
- allow saving introspection results as named projects in localStorage
- update layout for optional third pane

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689971f1a08883308598418966723b32