### PR TITLE
Persist auth config with projects

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
     if (!name) return;
     const newList = [
       ...projects.filter((p) => p.name !== name),
-      { name, result, baseUrl: lastPayload?.baseUrl },
+      { name, result, baseUrl: lastPayload?.baseUrl, payload: lastPayload },
     ];
     setProjects(newList);
     persist(newList);
@@ -40,9 +40,14 @@ export default function Page() {
   function handleSelectProject(p: Project) {
     setResult(p.result);
     setShowProjects(false);
+    if (p.payload) {
+      setLastPayload(p.payload);
+    } else if (p.baseUrl) {
+      setLastPayload({ baseUrl: p.baseUrl });
+    }
   }
 
-  async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string; authScheme?: string; authMethod?: string; queryName?: string }) {
+  async function onSubmit(payload: { baseUrl: string; apiKey?: string; headerName?: string; authScheme?: string; authMethod?: string; queryName?: string; useAuth?: boolean; authType?: string; customScheme?: string }) {
     setLoading(true); setError(null); setResult(null); setLastPayload(payload);
     try {
       const res = await fetch('/api/introspect', {
@@ -86,7 +91,7 @@ export default function Page() {
             Enter a base URL (OpenAPI/Swagger, GraphQL, or a JSON API). Optional API key is sent using your chosen header or query
             parameter.
           </p>
-          <ApiForm onSubmit={onSubmit} disabled={loading} />
+          <ApiForm onSubmit={onSubmit} disabled={loading} initial={lastPayload || undefined} />
         </section>
         <section className="card">
           <h2>Result</h2>

--- a/components/ProjectsPane.tsx
+++ b/components/ProjectsPane.tsx
@@ -5,6 +5,17 @@ export interface Project {
   name: string;
   result: any;
   baseUrl?: string;
+  payload?: {
+    baseUrl: string;
+    apiKey?: string;
+    headerName?: string;
+    authScheme?: string;
+    authMethod?: string;
+    queryName?: string;
+    authType?: string;
+    customScheme?: string;
+    useAuth?: boolean;
+  };
 }
 
 export default function ProjectsPane({ projects, onSelect, onClose }:{ projects: Project[]; onSelect:(p:Project)=>void; onClose:()=>void; }) {
@@ -18,7 +29,13 @@ export default function ProjectsPane({ projects, onSelect, onClose }:{ projects:
       <ul style={{listStyle:'none',padding:0,margin:0}}>
         {projects.map(p => (
           <li key={p.name} style={{marginTop:'.5rem'}}>
-            <button onClick={()=>onSelect(p)} style={{width:'100%',textAlign:'left'}}>{p.name}</button>
+            <button
+              onClick={()=>onSelect(p)}
+              title={p.name}
+              style={{width:'100%',textAlign:'left',whiteSpace:'nowrap',overflow:'hidden',textOverflow:'ellipsis'}}
+            >
+              {p.name}
+            </button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- Prevent project name overflow by truncating with ellipsis and showing full name on hover
- Save auth configuration with projects and restore API Explorer form from local storage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899749223f883309bcc5545108e6918