### PR TITLE
feat: display editable API call

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import ApiForm from "../components/ApiForm";
 import Explorer from "../components/Explorer";
+import ApiCallBuilder from "../components/ApiCallBuilder";
 import ProjectsPane, { Project } from "../components/ProjectsPane";
 
 export default function Page() {
@@ -76,6 +77,11 @@ export default function Page() {
         </button>
       )}
       <main className={`grid ${showProjects ? "with-projects" : ""}`}>
+        {lastPayload && (
+          <section className="card" style={{ gridColumn: "1 / -1" }}>
+            <ApiCallBuilder payload={lastPayload} />
+          </section>
+        )}
         {showProjects && (
           <section className="card" style={{ paddingLeft: 0 }}>
             <ProjectsPane

--- a/components/ApiCallBuilder.tsx
+++ b/components/ApiCallBuilder.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+interface Payload {
+  baseUrl: string;
+  apiKey?: string;
+  queryName?: string;
+  authMethod?: string;
+  useAuth?: boolean;
+}
+
+function buildUrl(p: Payload): string {
+  try {
+    const url = new URL(p.baseUrl);
+    if (p.useAuth && p.authMethod === "query" && p.apiKey && p.queryName) {
+      url.searchParams.set(p.queryName, p.apiKey);
+    }
+    return url.toString();
+  } catch {
+    let url = p.baseUrl;
+    if (p.useAuth && p.authMethod === "query" && p.apiKey && p.queryName) {
+      const sep = url.includes("?") ? "&" : "?";
+      url += `${sep}${p.queryName}=${encodeURIComponent(p.apiKey)}`;
+    }
+    return url;
+  }
+}
+
+export default function ApiCallBuilder({ payload }: { payload: Payload }) {
+  const [method, setMethod] = useState("GET");
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    setUrl(buildUrl(payload));
+  }, [payload]);
+
+  return (
+    <div style={{ display: "flex", gap: "0.5rem" }}>
+      <select
+        style={{ width: "auto" }}
+        value={method}
+        onChange={(e) => setMethod(e.target.value)}
+      >
+        {[
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+        ].map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </select>
+      <input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        style={{ flex: 1 }}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ApiCallBuilder component with method selector and full URL input
- show current request builder above explorer and results

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997c4f5894833081d8acbe3cd0d878